### PR TITLE
Thread safe

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ set(CMAKE_CXX_STANDARD 17)
 
 # - make sure we have a clean build
 set(CMAKE_CXX_FLAGS "-g")
+set(CMAKE_C_FLAGS "-g")
 
 # - check some OS dependent stuff
 INCLUDE (CheckIncludeFiles)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -53,6 +53,7 @@ add_library(opium4 STATIC
   opium4/opium_wx_interface.cpp
   opium4/samba_wnd.cpp
   opium4/samba_app.cpp
+  opium4/samba_evt_handler.cpp
   )
 
 target_include_directories(opium4

--- a/lib/opium4/opium.c
+++ b/lib/opium4/opium.c
@@ -26,6 +26,7 @@ typedef unsigned long long UInt64;
 #ifdef WXWIDGETS
 int OpiumExecWx(struct Cadre *cdr, struct SambaWnd *w);
 void OpiumRefreshAllWindows();
+void OpiumCheckThreadRefreshCall();
 #endif
 
 #define CHANGE_CURSEUR
@@ -348,7 +349,7 @@ int OpiumInit(char *display) {
 	}
 	/* {
 		char *pomme,*c;
-		pomme = "ð";
+		pomme = "ï¿½";
 		printf("(%s) Symbole pomme: ",__func__);
 		c = pomme; while(*c) printf("%02X",(unsigned char)*c++);
 		printf("\n");
@@ -1378,6 +1379,11 @@ int OpiumRefreshIf(OPIUM_REFRESH_CONDITION condition, Cadre cdr) {
 	WndFrame f; Cadre board;
 	int x,y,h,v; int haut,larg,dx,dy; int64 dispo;
 	char redimensionne,sans_fond,type,doit_terminer;
+
+#ifdef WXWIDGETS
+	// debug to check for calls from secondary threads
+	OpiumCheckThreadRefreshCall();
+#endif
 
 	if(DEBUG_OPIUM(1)) WndPrint("(%s) Commence avec %s '%s' %d x %d, affichage %d x %d\n",__func__,OpiumCdrType[(int)cdr->type],cdr->nom,cdr->larg,cdr->haut,cdr->dh,cdr->dv);
 	if(DEBUG_OPIUM(1)) WndPrint("(%s) Cadre %08llX a rafraichir\n",__func__,(UInt64)cdr);

--- a/lib/opium4/opium.c
+++ b/lib/opium4/opium.c
@@ -1831,6 +1831,13 @@ int OpiumManageWx(Cadre *cdr, struct SambaWnd *w, char type, int x, int y, int h
 			u.y = y;
 			u.code = (unsigned int)WND_MSERIGHT;
 			break;
+
+		case 8: //SMBWX_DELETE
+			u.type = WND_DELETE;
+			u.x = 0;
+			u.y = 0;
+			break;
+
 	}
 
 	int cdr_ouverts = 0;

--- a/lib/opium4/opium_wx_interface.cpp
+++ b/lib/opium4/opium_wx_interface.cpp
@@ -46,6 +46,12 @@ void GetFontInfo(short *width, short *ascent, short *descent, short *leading)
 
 struct SambaWnd *WndCreateWx(int x, int y, unsigned int width, unsigned int height)
 {
+    if (!wxThread::IsMain())
+    {
+        std::cout << "WARNING:     WndCreateWx FROM SECONDARY" << std::endl;
+        return NULL;
+    }
+
     SambaWnd *w = theApp->WndCreate(x, y, width, height);
 
     if (mouse_click_window)
@@ -73,6 +79,11 @@ std::unique_ptr<wxDC> MakeDCPtr(SambaWnd *w)
 void WndDrawStringWx(struct SambaWnd *w, int x, int y, char *text, unsigned short fr, unsigned short fg, unsigned short fb, 
                     unsigned short br, unsigned short bg, unsigned short bb, char draw_bg )
 {
+    if (!wxThread::IsMain())
+    {
+        return;
+    }
+
     std::unique_ptr<wxDC> dc = MakeDCPtr(w);
     dc->SetTextForeground(wxColour{(unsigned char)(255 * fr/65535), (unsigned char)(255 * fg/65535), (unsigned char)(255 * fb/65535)});
     dc->SetTextBackground(wxColour{(unsigned char)(255 * br/65535), (unsigned char)(255 * bg/65535), (unsigned char)(255 * bb/65535)});
@@ -86,6 +97,11 @@ void WndDrawStringWx(struct SambaWnd *w, int x, int y, char *text, unsigned shor
 
 void WndDrawRectWx(struct SambaWnd *w, int x, int y, int width, int height, unsigned short r, unsigned short g, unsigned short b)
 {
+    if (!wxThread::IsMain())
+    {
+        return;
+    }
+
     std::unique_ptr<wxDC> dc = MakeDCPtr(w);
     dc->SetBrush(wxBrush{wxColour{(unsigned char)(255 * r/65535), (unsigned char)(255 * g/65535), (unsigned char)(255 * b/65535)}});
     dc->SetPen(wxPen(wxPen{wxColour{(unsigned char)(255 * r/65535), (unsigned char)(255 * g/65535), (unsigned char)(255 * b/65535)}}));
@@ -94,6 +110,11 @@ void WndDrawRectWx(struct SambaWnd *w, int x, int y, int width, int height, unsi
 
 void WndDrawLineWx(struct SambaWnd *w, int x0, int y0, int x1, int y1, short r, short g, short b)
 {
+    if (!wxThread::IsMain())
+    {
+        return;
+    }
+
     std::unique_ptr<wxDC> dc = MakeDCPtr(w);
     dc->SetBrush(wxBrush{wxColour{(unsigned char)r, (unsigned char)g, (unsigned char)b}});
     dc->SetPen(wxPen(wxPen{wxColour{(unsigned char)r, (unsigned char)g, (unsigned char)b}}));
@@ -103,6 +124,11 @@ void WndDrawLineWx(struct SambaWnd *w, int x0, int y0, int x1, int y1, short r, 
 
 void WndDrawPolyWx(struct SambaWnd *w, int *x, int *y, int num, short r, short g, short b)
 {
+    if (!wxThread::IsMain())
+    {
+        return;
+    }
+
     std::unique_ptr<wxDC> dc = MakeDCPtr(w);
     dc->SetBrush(wxBrush{wxColour{(unsigned char)r, (unsigned char)g, (unsigned char)b}});
     dc->SetPen(wxPen(wxPen{wxColour{(unsigned char)r, (unsigned char)g, (unsigned char)b}}));
@@ -118,6 +144,11 @@ void WndDrawPolyWx(struct SambaWnd *w, int *x, int *y, int num, short r, short g
 
 void WndDrawArcWx(struct SambaWnd *w, int x, int y, int width, int height, int start, int stop, short r, short g, short b)
 {
+    if (!wxThread::IsMain())
+    {
+        return;
+    }
+
     std::unique_ptr<wxDC> dc = MakeDCPtr(w);
     dc->SetBrush(*wxTRANSPARENT_BRUSH);
     dc->SetPen(wxPen(wxPen{wxColour{(unsigned char)r, (unsigned char)g, (unsigned char)b}}));
@@ -128,21 +159,41 @@ void WndDrawArcWx(struct SambaWnd *w, int x, int y, int width, int height, int s
 
 void WndMoveWx(struct SambaWnd *w, int x, int y)
 {
+    if (!wxThread::IsMain())
+    {
+        return;
+    }
+
     w->Move(x, y);
 }
 
 void WndResizeWx(struct SambaWnd *w, int h, int v)
 {
+    if (!wxThread::IsMain())
+    {
+        return;
+    }
+
     w->SetSize(w->GetPosition().x, w->GetPosition().y, h, v);
 }
 
 void WndClearWx(struct SambaWnd *w)
 {
+    if (!wxThread::IsMain())
+    {
+        return;
+    }
+
     w->Close();
 }
 
 void WndShowTheTopWx(struct SambaWnd *w)
 {
+    if (!wxThread::IsMain())
+    {
+        return;
+    }
+
     w->Raise();
     w->SetFocus();
 }
@@ -164,6 +215,14 @@ int OpiumExecWx(struct Cadre *cdr, SambaWnd *w)
     }
 
     return 0;
+}
+
+void OpiumCheckThreadRefreshCall()
+{
+    if (!wxThread::IsMain())
+    {
+        std::cout << "WARNING: OpiumRefreshIf called from secondary thread" << std::endl;
+    }
 }
 
 void OpiumRefreshAllWindows()

--- a/lib/opium4/opium_wx_interface.cpp
+++ b/lib/opium4/opium_wx_interface.cpp
@@ -50,7 +50,9 @@ struct SambaWnd *WndCreateWx(int x, int y, unsigned int width, unsigned int heig
 {
     if (!wxThread::IsMain())
     {
-        std::cout << "WARNING:     WndCreateWx FROM SECONDARY" << std::endl;
+        // we're not the main thread so send an event and wait for return
+        wxCommandEvent event(CREATE_WINDOW);
+        wxQueueEvent(&theApp->evtHandler_, event);
         return NULL;
     }
 
@@ -67,6 +69,47 @@ struct SambaWnd *WndCreateWx(int x, int y, unsigned int width, unsigned int heig
 void WndTitleWx(struct SambaWnd *w, char *title)
 {
     w->SetLabel(title);
+}
+
+void WndMoveWx(struct SambaWnd *w, int x, int y)
+{
+    if (!wxThread::IsMain())
+    {
+        return;
+    }
+
+    w->Move(x, y);
+}
+
+void WndResizeWx(struct SambaWnd *w, int h, int v)
+{
+    if (!wxThread::IsMain())
+    {
+        return;
+    }
+
+    w->SetSize(w->GetPosition().x, w->GetPosition().y, h, v);
+}
+
+void WndClearWx(struct SambaWnd *w)
+{
+    if (!wxThread::IsMain())
+    {
+        return;
+    }
+
+    w->Close();
+}
+
+void WndShowTheTopWx(struct SambaWnd *w)
+{
+    if (!wxThread::IsMain())
+    {
+        return;
+    }
+
+    w->Raise();
+    w->SetFocus();
 }
 
 std::unique_ptr<wxDC> MakeDCPtr(SambaWnd *w)
@@ -158,47 +201,6 @@ void WndDrawArcWx(struct SambaWnd *w, int x, int y, int width, int height, int s
     dc->DrawEllipticArc(x, y, width, height, start, stop);
 }
 
-
-void WndMoveWx(struct SambaWnd *w, int x, int y)
-{
-    if (!wxThread::IsMain())
-    {
-        return;
-    }
-
-    w->Move(x, y);
-}
-
-void WndResizeWx(struct SambaWnd *w, int h, int v)
-{
-    if (!wxThread::IsMain())
-    {
-        return;
-    }
-
-    w->SetSize(w->GetPosition().x, w->GetPosition().y, h, v);
-}
-
-void WndClearWx(struct SambaWnd *w)
-{
-    if (!wxThread::IsMain())
-    {
-        return;
-    }
-
-    w->Close();
-}
-
-void WndShowTheTopWx(struct SambaWnd *w)
-{
-    if (!wxThread::IsMain())
-    {
-        return;
-    }
-
-    w->Raise();
-    w->SetFocus();
-}
 int OpiumExecWx(struct Cadre *cdr, SambaWnd *w)
 {
     if (samba_running)

--- a/lib/opium4/opium_wx_interface.cpp
+++ b/lib/opium4/opium_wx_interface.cpp
@@ -101,6 +101,8 @@ void WndClearWx(struct SambaWnd *w)
 {
     if (!wxThread::IsMain())
     {
+        wxCommandEvent event(REQUEST_CLOSE);
+        wxQueueEvent(w, event.Clone());
         return;
     }
 

--- a/lib/opium4/opium_wx_interface.cpp
+++ b/lib/opium4/opium_wx_interface.cpp
@@ -213,9 +213,18 @@ int OpiumExecWx(struct Cadre *cdr, SambaWnd *w)
 {
     if (samba_running)
     {
-        // called for a modal dialog
-        w->Show( false );
-        w->ShowModal();
+        if (wxThread::IsMain())
+        {
+            // called for a modal dialog
+            w->Show( false );
+            w->ShowModal();
+        }
+        else
+        {
+            // we're not the main thread so send an event and wait for return
+            w->ExecModal();
+        }
+
         return last_evt_ret_code;
     } else {
         // called for main running

--- a/lib/opium4/opium_wx_interface.cpp
+++ b/lib/opium4/opium_wx_interface.cpp
@@ -51,9 +51,7 @@ struct SambaWnd *WndCreateWx(int x, int y, unsigned int width, unsigned int heig
     if (!wxThread::IsMain())
     {
         // we're not the main thread so send an event and wait for return
-        wxCommandEvent event(CREATE_WINDOW);
-        wxQueueEvent(&theApp->evtHandler_, event);
-        return NULL;
+        return theApp->SendWndCreateEvent(x, y, width, height);
     }
 
     SambaWnd *w = theApp->WndCreate(x, y, width, height);
@@ -68,6 +66,14 @@ struct SambaWnd *WndCreateWx(int x, int y, unsigned int width, unsigned int heig
 
 void WndTitleWx(struct SambaWnd *w, char *title)
 {
+    if (!wxThread::IsMain())
+    {
+        wxCommandEvent event(SET_WND_TITLE);
+        event.SetString(title);
+        wxQueueEvent(w, event.Clone());
+        return;
+    }
+
     w->SetLabel(title);
 }
 

--- a/lib/opium4/opium_wx_interface.cpp
+++ b/lib/opium4/opium_wx_interface.cpp
@@ -7,6 +7,7 @@
 
 #include <iostream>
 #include <execinfo.h>
+#include <mutex>
 
 wxFont *theFont{nullptr};
 SambaApp *theApp{nullptr};
@@ -15,6 +16,7 @@ bool samba_running{false};
 bool in_paint_event{false};
 int last_evt_ret_code{0};
 SambaWnd *mouse_click_window{nullptr};
+std::mutex paint_mtx;
 
 void InitWxWidgetsApp(int *scr_width, int *scr_height)
 {
@@ -256,6 +258,16 @@ void WndGetWindowSizeWx(struct SambaWnd *w, int *width, int *height)
 {
     *width = w->GetClientSize().GetWidth();
     *height = w->GetClientSize().GetHeight();
+}
+
+void LockPaintEvents()
+{
+    paint_mtx.lock();
+}
+
+void UnlockPaintEvents()
+{
+    paint_mtx.unlock();
 }
 
 #endif // WXWIDGETS

--- a/lib/opium4/opium_wx_interface.cpp
+++ b/lib/opium4/opium_wx_interface.cpp
@@ -106,7 +106,7 @@ void WndClearWx(struct SambaWnd *w)
         return;
     }
 
-    w->Close();
+    w->MenuClose();
 }
 
 void WndShowTheTopWx(struct SambaWnd *w)

--- a/lib/opium4/opium_wx_interface.h
+++ b/lib/opium4/opium_wx_interface.h
@@ -39,4 +39,6 @@ EXTERNC void WndClearWx(struct SambaWnd *w);
 EXTERNC void WndShowTheTopWx(struct SambaWnd *w);
 EXTERNC struct wxCursor *WndCreateStdCursorWx();
 EXTERNC void WndGetWindowSizeWx(struct SambaWnd *w, int *width, int *height);
+EXTERNC void LockPaintEvents();
+EXTERNC void UnlockPaintEvents();
 #endif

--- a/lib/opium4/opium_wx_interface.h
+++ b/lib/opium4/opium_wx_interface.h
@@ -9,8 +9,8 @@ enum SambaEventWx {
     SMBWX_FOCUS,
     SMBWX_KEY,
     SMBWX_MOUSE_RIGHT_DOWN,
-    SMBWX_MOUSE_RIGHT_UP
-
+    SMBWX_MOUSE_RIGHT_UP,
+    SMBWX_DELETE
 };
 
 #ifdef __cplusplus

--- a/lib/opium4/opium_wx_interface.h
+++ b/lib/opium4/opium_wx_interface.h
@@ -24,6 +24,7 @@ EXTERNC void InitWxWidgetsApp(int *scr_width, int *scr_height);
 EXTERNC void GetFontInfo(short *width, short *ascent, short *descent, short *leading);
 EXTERNC int OpiumExecWx(struct Cadre *cdr, struct SambaWnd *w);
 EXTERNC void OpiumRefreshAllWindows();
+EXTERNC void OpiumCheckThreadRefreshCall();
 EXTERNC struct SambaWnd *WndCreateWx(int x, int y, unsigned int width, unsigned int height);
 EXTERNC void WndTitleWx(struct SambaWnd *w, char *title);
 EXTERNC void WndDrawStringWx(struct SambaWnd *w, int x, int y, char *text, unsigned short fr, unsigned short fg, unsigned short fb, 

--- a/lib/opium4/prompts.c
+++ b/lib/opium4/prompts.c
@@ -427,7 +427,12 @@ int OpiumRunPrompt(Cadre cdr, WndUserRequest *e) {
 		}
 	} else if(e->type == WND_RELEASE) switch(e->code) {
 	  case WND_MSELEFT:
+#ifdef WXWIDGETS
+		// for wx widgets, the buttons are placed on line 2
+		if(lig == 2) {
+#else
 		if(lig == 1) {
+#endif
 			if(OpiumPromptNb == 1) code_rendu = 1;
 			else { h = cdr->larg / OpiumPromptNb; code_rendu = e->x / h; }
 		};

--- a/lib/opium4/samba_app.cpp
+++ b/lib/opium4/samba_app.cpp
@@ -17,9 +17,15 @@ SambaWnd *SambaApp::WndCreate(int x, int y, unsigned int width, unsigned int hei
     SambaWnd *wnd = new SambaWnd( "Hello World", wxPoint(x, y), wxSize(width, height) );
     wnd->Show( true );
     wnd->SetClientSize(wxSize(width, height));
-    
+    wnd->SetSambaApp(this);
+
     wndList_.push_back(wnd);
     return wnd;
+}
+
+void SambaApp::RemoveWindow(SambaWnd *w)
+{
+    wndList_.erase( std::remove(wndList_.begin(), wndList_.end(), w), wndList_.end() );
 }
 
 void SambaApp::ManageWndCreateEvent(int x, int y, unsigned int width, unsigned int height)

--- a/lib/opium4/samba_app.cpp
+++ b/lib/opium4/samba_app.cpp
@@ -27,4 +27,5 @@ void SambaApp::UpdateAllWindows()
     }
 }
 
+
 #endif

--- a/lib/opium4/samba_app.hpp
+++ b/lib/opium4/samba_app.hpp
@@ -8,6 +8,7 @@
 
 #include <samba_wnd.hpp>
 #include <vector>
+#include <samba_evt_handler.hpp>
 
 class SambaApp: public wxApp
 {
@@ -18,8 +19,11 @@ public:
     virtual bool OnInit();
     void StartRenderTimer();
     void UpdateAllWindows();
-
+    
     SambaWnd *WndCreate(int x, int y, unsigned int width, unsigned int height);
+
+    SambaEvtHandler evtHandler_;
+
 };
 
 #endif

--- a/lib/opium4/samba_app.hpp
+++ b/lib/opium4/samba_app.hpp
@@ -27,7 +27,7 @@ public:
     SambaEvtHandler evtHandler_;
     std::atomic_bool creationDone_{false};
     SambaWnd *lastWindowCreated_{nullptr};
-
+    void RemoveWindow(SambaWnd *w);
 };
 
 #endif

--- a/lib/opium4/samba_app.hpp
+++ b/lib/opium4/samba_app.hpp
@@ -8,6 +8,7 @@
 
 #include <samba_wnd.hpp>
 #include <vector>
+#include <atomic>
 #include <samba_evt_handler.hpp>
 
 class SambaApp: public wxApp

--- a/lib/opium4/samba_app.hpp
+++ b/lib/opium4/samba_app.hpp
@@ -19,10 +19,14 @@ public:
     virtual bool OnInit();
     void StartRenderTimer();
     void UpdateAllWindows();
-    
+
     SambaWnd *WndCreate(int x, int y, unsigned int width, unsigned int height);
+    SambaWnd *SendWndCreateEvent(int x, int y, unsigned int width, unsigned int height);
+    void ManageWndCreateEvent(int x, int y, unsigned int width, unsigned int height);
 
     SambaEvtHandler evtHandler_;
+    std::atomic_bool creationDone_{false};
+    SambaWnd *lastWindowCreated_{nullptr};
 
 };
 

--- a/lib/opium4/samba_app.hpp
+++ b/lib/opium4/samba_app.hpp
@@ -7,6 +7,7 @@
 #endif
 
 #include <samba_wnd.hpp>
+#include <vector>
 
 class SambaApp: public wxApp
 {

--- a/lib/opium4/samba_evt_handler.cpp
+++ b/lib/opium4/samba_evt_handler.cpp
@@ -1,14 +1,16 @@
-
 #include <samba_evt_handler.hpp>
+#include <samba_app.hpp>
+#include <opium_wx_interface.h>
 
 // define global window handling events
 wxDEFINE_EVENT(CREATE_WINDOW, wxCommandEvent);
 
-wxBEGIN_EVENT_TABLE(SambaWnd, wxDialog)
+wxBEGIN_EVENT_TABLE(SambaEvtHandler, wxEvtHandler)
     EVT_COMMAND(wxID_ANY, CREATE_WINDOW, SambaEvtHandler::OnCreateWindow)
 wxEND_EVENT_TABLE()
 
 void SambaEvtHandler::OnCreateWindow(wxCommandEvent& event)
 {
-    std::cout << "CREATE WINDOW" << std::endl;
+    NewWindowConfig *cfg{static_cast<NewWindowConfig*>(event.GetClientData())};
+    theApp_->ManageWndCreateEvent(cfg->x, cfg->y, cfg->width, cfg->height);
 }

--- a/lib/opium4/samba_evt_handler.cpp
+++ b/lib/opium4/samba_evt_handler.cpp
@@ -1,0 +1,14 @@
+
+#include <samba_evt_handler.hpp>
+
+// define global window handling events
+wxDEFINE_EVENT(CREATE_WINDOW, wxCommandEvent);
+
+wxBEGIN_EVENT_TABLE(SambaWnd, wxDialog)
+    EVT_COMMAND(wxID_ANY, CREATE_WINDOW, SambaEvtHandler::OnCreateWindow)
+wxEND_EVENT_TABLE()
+
+void SambaEvtHandler::OnCreateWindow(wxCommandEvent& event)
+{
+    std::cout << "CREATE WINDOW" << std::endl;
+}

--- a/lib/opium4/samba_evt_handler.hpp
+++ b/lib/opium4/samba_evt_handler.hpp
@@ -6,11 +6,29 @@
     #include <wx/wx.h>
 #endif
 
+wxDECLARE_EVENT(CREATE_WINDOW, wxCommandEvent);
+
+class SambaApp;
+
+
+struct NewWindowConfig
+{
+    int x;
+    int y;
+    unsigned int width;
+    unsigned int height;
+};
+
 class SambaEvtHandler: public wxEvtHandler
 {
+private:
+    SambaApp *theApp_{nullptr};
+
 public:
     void OnCreateWindow(wxCommandEvent& event);
+    void SetAppPointer(SambaApp *ptr) {theApp_ = ptr;}
 
+    wxDECLARE_EVENT_TABLE();
 };
 
 #endif

--- a/lib/opium4/samba_evt_handler.hpp
+++ b/lib/opium4/samba_evt_handler.hpp
@@ -1,0 +1,16 @@
+#ifndef SAMBA_EVT_HANDLER_HPP
+#define SAMBA_EVT_HANDLER_HPP
+
+#include <wx/wxprec.h>
+#ifndef WX_PRECOMP
+    #include <wx/wx.h>
+#endif
+
+class SambaEvtHandler: public wxEvtHandler
+{
+public:
+    void OnCreateWindow(wxCommandEvent& event);
+
+};
+
+#endif

--- a/lib/opium4/samba_wnd.cpp
+++ b/lib/opium4/samba_wnd.cpp
@@ -157,7 +157,14 @@ void SambaWnd::OnClose(wxCloseEvent& event)
 
     // OS request to close so send an event instead
     // should probably *not* do this if DAQ is running....
-    WndEventNewWx(this, SMBWX_DELETE, 0, 0, 0, 0);
+    // Also, this doesn't seem to work with modal dialogs properly so just disable it in that instance
+    if (IsModal() && event.CanVeto())
+    {
+        event.Veto();
+        return;
+    } else {
+        WndEventNewWx(this, SMBWX_DELETE, 0, 0, 0, 0);
+    }
 }
 
 #endif //WXWIDGETS

--- a/lib/opium4/samba_wnd.cpp
+++ b/lib/opium4/samba_wnd.cpp
@@ -6,6 +6,7 @@
 
 // create a custom event to request a refresh OUTSIDE the main GUI thread
 wxDEFINE_EVENT(REQUEST_UPDATE, wxCommandEvent);
+wxDEFINE_EVENT(SET_WND_TITLE, wxCommandEvent);
 
 wxBEGIN_EVENT_TABLE(SambaWnd, wxDialog)
     EVT_SIZE(SambaWnd::OnSize)
@@ -19,6 +20,7 @@ wxBEGIN_EVENT_TABLE(SambaWnd, wxDialog)
     EVT_CHAR_HOOK(SambaWnd::OnKeyChar)
     EVT_TIMER(1, SambaWnd::OnTimer)
     EVT_COMMAND(wxID_ANY, REQUEST_UPDATE, SambaWnd::OnRequestUpdate)
+    EVT_COMMAND(wxID_ANY, SET_WND_TITLE, SambaWnd::OnSetWndTitle)
 wxEND_EVENT_TABLE()
 
 void WndEventNewWx(struct SambaWnd *w, enum SambaEventWx type, int x, int y, int h, int v);
@@ -122,6 +124,11 @@ void SambaWnd::RequestUpdate()
 void SambaWnd::OnRequestUpdate(wxCommandEvent& event)
 {
     Refresh();
+}
+
+void SambaWnd::OnSetWndTitle(wxCommandEvent& event)
+{
+    SetLabel(event.GetString());
 }
 
 #endif //WXWIDGETS

--- a/lib/opium4/samba_wnd.cpp
+++ b/lib/opium4/samba_wnd.cpp
@@ -7,6 +7,7 @@
 // create a custom event to request a refresh OUTSIDE the main GUI thread
 wxDEFINE_EVENT(REQUEST_UPDATE, wxCommandEvent);
 wxDEFINE_EVENT(SET_WND_TITLE, wxCommandEvent);
+wxDEFINE_EVENT(REQUEST_CLOSE, wxCommandEvent);
 
 wxBEGIN_EVENT_TABLE(SambaWnd, wxDialog)
     EVT_SIZE(SambaWnd::OnSize)
@@ -21,6 +22,7 @@ wxBEGIN_EVENT_TABLE(SambaWnd, wxDialog)
     EVT_TIMER(1, SambaWnd::OnTimer)
     EVT_COMMAND(wxID_ANY, REQUEST_UPDATE, SambaWnd::OnRequestUpdate)
     EVT_COMMAND(wxID_ANY, SET_WND_TITLE, SambaWnd::OnSetWndTitle)
+    EVT_COMMAND(wxID_ANY, REQUEST_CLOSE, SambaWnd::OnRequestClose)
 wxEND_EVENT_TABLE()
 
 void WndEventNewWx(struct SambaWnd *w, enum SambaEventWx type, int x, int y, int h, int v);
@@ -129,6 +131,12 @@ void SambaWnd::OnRequestUpdate(wxCommandEvent& event)
 void SambaWnd::OnSetWndTitle(wxCommandEvent& event)
 {
     SetLabel(event.GetString());
+}
+
+void SambaWnd::OnRequestClose(wxCommandEvent& event)
+{
+    theApp_->RemoveWindow(this);
+    Close();
 }
 
 #endif //WXWIDGETS

--- a/lib/opium4/samba_wnd.cpp
+++ b/lib/opium4/samba_wnd.cpp
@@ -10,6 +10,7 @@ wxDEFINE_EVENT(SET_WND_TITLE, wxCommandEvent);
 wxDEFINE_EVENT(REQUEST_CLOSE, wxCommandEvent);
 
 wxBEGIN_EVENT_TABLE(SambaWnd, wxDialog)
+    EVT_CLOSE(SambaWnd::OnClose)
     EVT_SIZE(SambaWnd::OnSize)
     EVT_MOVE(SambaWnd::OnMove)
     EVT_PAINT(SambaWnd::OnPaint)
@@ -135,8 +136,28 @@ void SambaWnd::OnSetWndTitle(wxCommandEvent& event)
 
 void SambaWnd::OnRequestClose(wxCommandEvent& event)
 {
-    theApp_->RemoveWindow(this);
+    MenuClose();
+}
+
+void SambaWnd::MenuClose()
+{
+    menuClose_ = true;
     Close();
+}
+
+void SambaWnd::OnClose(wxCloseEvent& event)
+{
+    // closing from a menu or samba request so just destroy the window
+    if (menuClose_)
+    {
+        theApp_->RemoveWindow(this);
+        event.Skip();
+        return;
+    }
+
+    // OS request to close so send an event instead
+    // should probably *not* do this if DAQ is running....
+    WndEventNewWx(this, SMBWX_DELETE, 0, 0, 0, 0);
 }
 
 #endif //WXWIDGETS

--- a/lib/opium4/samba_wnd.cpp
+++ b/lib/opium4/samba_wnd.cpp
@@ -54,9 +54,11 @@ void SambaWnd::OnMove(wxMoveEvent& /*event*/)
 
 void SambaWnd::OnPaint(wxPaintEvent& /*event*/)
 {
+    LockPaintEvents();
     is_painting = true;
     WndEventNewWx(this, SMBWX_PAINT, 0, 0, 0, 0);
     is_painting = false;
+    UnlockPaintEvents();
 }
 
 void SambaWnd::IgnoreNextMouseRelease()

--- a/lib/opium4/samba_wnd.hpp
+++ b/lib/opium4/samba_wnd.hpp
@@ -9,6 +9,8 @@
 #include <string>
 #include "opium_wx_interface.h"
 
+wxDECLARE_EVENT(SET_WND_TITLE, wxCommandEvent);
+
 class SambaWnd: public wxDialog
 {
 public:
@@ -28,6 +30,7 @@ private:
     void OnFocus(wxFocusEvent& event);
     void OnKeyChar(wxKeyEvent& event);
     void OnRequestUpdate(wxCommandEvent& event);
+    void OnSetWndTitle(wxCommandEvent& event);
     wxDECLARE_EVENT_TABLE();
 
     bool is_painting{false};

--- a/lib/opium4/samba_wnd.hpp
+++ b/lib/opium4/samba_wnd.hpp
@@ -24,8 +24,10 @@ public:
     void OnTimer(wxTimerEvent& event);
     void IgnoreNextMouseRelease();
     void SetSambaApp(SambaApp *app) {theApp_ = app;}
+    void MenuClose();
 
 private:
+    void OnClose(wxCloseEvent& event);
     void OnSize(wxSizeEvent& event);
     void OnMove(wxMoveEvent& event);
     void OnPaint(wxPaintEvent& event);
@@ -44,6 +46,7 @@ private:
     bool ignoreMouseRelease_{false};
     SambaEventWx lastMouseButton_{SMBWX_MOUSE_LEFT_DOWN};
     SambaApp *theApp_;
+    bool menuClose_{false};
 };
 
 #endif

--- a/lib/opium4/samba_wnd.hpp
+++ b/lib/opium4/samba_wnd.hpp
@@ -10,6 +10,9 @@
 #include "opium_wx_interface.h"
 
 wxDECLARE_EVENT(SET_WND_TITLE, wxCommandEvent);
+wxDECLARE_EVENT(REQUEST_CLOSE, wxCommandEvent);
+
+class SambaApp;
 
 class SambaWnd: public wxDialog
 {
@@ -20,6 +23,7 @@ public:
     void RequestUpdate();
     void OnTimer(wxTimerEvent& event);
     void IgnoreNextMouseRelease();
+    void SetSambaApp(SambaApp *app) {theApp_ = app;}
 
 private:
     void OnSize(wxSizeEvent& event);
@@ -31,6 +35,7 @@ private:
     void OnKeyChar(wxKeyEvent& event);
     void OnRequestUpdate(wxCommandEvent& event);
     void OnSetWndTitle(wxCommandEvent& event);
+    void OnRequestClose(wxCommandEvent& event);
     wxDECLARE_EVENT_TABLE();
 
     bool is_painting{false};
@@ -38,6 +43,7 @@ private:
     wxPoint mousePos_;
     bool ignoreMouseRelease_{false};
     SambaEventWx lastMouseButton_{SMBWX_MOUSE_LEFT_DOWN};
+    SambaApp *theApp_;
 };
 
 #endif

--- a/lib/opium4/samba_wnd.hpp
+++ b/lib/opium4/samba_wnd.hpp
@@ -8,6 +8,7 @@
 
 #include <string>
 #include "opium_wx_interface.h"
+#include <atomic>
 
 wxDECLARE_EVENT(SET_WND_TITLE, wxCommandEvent);
 wxDECLARE_EVENT(REQUEST_CLOSE, wxCommandEvent);
@@ -25,6 +26,7 @@ public:
     void IgnoreNextMouseRelease();
     void SetSambaApp(SambaApp *app) {theApp_ = app;}
     void MenuClose();
+    void ExecModal();
 
 private:
     void OnClose(wxCloseEvent& event);
@@ -38,6 +40,7 @@ private:
     void OnRequestUpdate(wxCommandEvent& event);
     void OnSetWndTitle(wxCommandEvent& event);
     void OnRequestClose(wxCommandEvent& event);
+    void OnRunModal(wxCommandEvent&);
     wxDECLARE_EVENT_TABLE();
 
     bool is_painting{false};
@@ -47,6 +50,7 @@ private:
     SambaEventWx lastMouseButton_{SMBWX_MOUSE_LEFT_DOWN};
     SambaApp *theApp_;
     bool menuClose_{false};
+    std::atomic_bool modalDone_{false};
 };
 
 #endif

--- a/samba/calculs.c
+++ b/samba/calculs.c
@@ -34,6 +34,11 @@
 #include <monit.h>
 #include <autom.h>
 
+#ifdef WXWIDGETS
+#include <pthread.h>
+void OpiumRefreshAllWindows();
+#endif
+
 typedef enum {
 	AVEC_T1 = 0,
 	NB_POINTS
@@ -794,10 +799,14 @@ int CalcSpectreAutoParms() {
 /* ========================================================================== */
 #endif /* SPECTRES_SEQUENCES */
 
-int LectSpectresAutoMesure(),LectStop();
+int LectSpectresAutoMesure(),LectSpectresAutoMesureMT(),LectStop();
 int CalcSpectreAutoAffiche(),CalcSpectreAutoSauve(),CalcSpectreAutoEfface(),CalcSpectreAutoRetrouve();
 MenuItem iCalcSpectreControle[] = {
+#ifdef WXWIDGETS
+	{ "Mesurer  ",  MNU_FONCTION LectSpectresAutoMesureMT },
+#else
 	{ "Mesurer  ",  MNU_FONCTION LectSpectresAutoMesure },
+#endif
 	{ "Afficher ",  MNU_FONCTION CalcSpectreAutoAffiche },
 	{ "Stopper  ",  MNU_FONCTION LectStop },
 	{ "Sauver   ",  MNU_FONCTION CalcSpectreAutoSauve },
@@ -1024,11 +1033,15 @@ int CalcSpectreAutoConstruit() {
 /* ========================================================================== */
 int CalcSpectreAutoAffiche() {
 	int i;
-	
+
+#ifndef WXWIDGETS
 	for(i=0; i<CalcSpectreFenNb; i++) {
 		if(!LectCompacteUtilisee) OpiumDisplay(gCalcSpectreAffiche[i]->cdr);
 		else OpiumRefresh(gCalcSpectreAffiche[i]->cdr);
 	}
+#else
+		OpiumRefreshAllWindows();
+#endif
 	
 	return(0);
 }

--- a/samba/lect.c
+++ b/samba/lect.c
@@ -3449,7 +3449,6 @@ void LectActionUtilisateur() {
 #ifdef MSGS_RESEAU
 	char msg[256];
 #endif
-
 	LectDansActionUtilisateur = 1;
 	/* Action utilisateur possible */
 	/* { struct timeval heure;
@@ -9136,6 +9135,30 @@ int LectSpectresAutoMesure(Menu menu, MenuItem *item) {
 	
 	return(0);
 }
+
+struct LectSpectresAutoMesureArgs {
+	Menu menu;
+	MenuItem *item;
+};
+
+static int LectSpectresAutoMesureThread(void *args_ptr) {
+	struct LectSpectresAutoMesureArgs* args = (struct LectSpectresAutoMesureArgs*) args_ptr;
+	int ret = LectSpectresAutoMesure(args->menu, args->item);
+	free(args);
+	return ret;
+}
+
+int LectSpectresAutoMesureMT(Menu menu, MenuItem *item) {
+	// call LectSpectresAutoMesure in a separate thread to avoid blocking
+	struct LectSpectresAutoMesureArgs *args = malloc(sizeof(struct LectSpectresAutoMesureArgs));
+	args->menu = menu;
+	args->item = item;
+
+	pthread_t thd;
+	int t = pthread_create(&thd, NULL, LectSpectresAutoMesureThread, args);
+	return 0;
+}
+
 #ifdef SPECTRES_COMPACTE
 /* ========================================================================== */
 int LectCompacteSpectres(Menu menu, MenuItem *item) {

--- a/samba/lect.c
+++ b/samba/lect.c
@@ -7602,12 +7602,6 @@ static void LecTraiteFromIt() {
 #pragma mark ---- Commandes executives ----
 #define MAX_ERREURS 0
 
-struct arg_struct {
-    char boostee;
-    char it_demandees;
-    NUMER_MODE mode;
-};
-
 static TypeADU LectExec(NUMER_MODE mode) {
 /* /docFuncBeg {LectExec}
    	/docFuncReturn  {0 si OK, code d'erreur sinon (voir LectAcqStd)}
@@ -7748,11 +7742,6 @@ static TypeADU LectExec(NUMER_MODE mode) {
  * Depart sur une synchro (D2 ou D3)
  * ---------------------------------
  */
-		struct arg_struct args;
-		args.boostee = boostee;
-		args.it_demandees = it_demandees;
-		args.mode = mode;
-
 relance:
 	min_restart = 100; // 5000; // 5s
 	Acquis[AcquisLocale].etat.active = LectSynchro(mode);

--- a/samba/lect.c
+++ b/samba/lect.c
@@ -8614,14 +8614,6 @@ int LectAcqElementaire(NUMER_MODE mode) {
 	return(0);
 }
 /* ========================================================================== */
-int LectAcqStdThreadWrapper() {
-	// do a wrapper to ensure the painting lock is released
-	LockPaintEvents();
-	int ret = LectAcqStdThread();
-	UnlockPaintEvents();
-	return ret;
-}
-
 int LectAcqStdThread() {
 	int rep,voie,rc,i,k,l,num,fmt; char doit_terminer;
 	TypeADU erreur_acq;
@@ -9078,6 +9070,14 @@ int LectAcqStdThread() {
 
 	OpiumRefreshAllWindows();
 	return(0);
+}
+
+int LectAcqStdThreadWrapper() {
+	// do a wrapper to ensure the painting lock is released
+	LockPaintEvents();
+	int ret = LectAcqStdThread();
+	UnlockPaintEvents();
+	return ret;
 }
 
 int LectAcqStd() {

--- a/samba/lect.c
+++ b/samba/lect.c
@@ -8603,7 +8603,7 @@ int LectAcqElementaire(NUMER_MODE mode) {
 	return(0);
 }
 /* ========================================================================== */
-int LectAcqStdThread() {
+int LectAcqStd() {
 	int rep,voie,rc,i,k,l,num,fmt; char doit_terminer;
 	TypeADU erreur_acq;
 	float nb;
@@ -8643,16 +8643,12 @@ int LectAcqStdThread() {
 #endif
 	do {
 		if(LectSession < 2) {
-#ifndef WXWIDGETS
 			if(!LectFixeMode(LECT_DONNEES,1)) return(0);
-#endif
 			for(rep=0; rep<RepartNb; rep++) {
 				Repart[rep].mode = 0;
 				Repart[rep].status_demande = 0;
 			}
-#ifndef WXWIDGETS
 			LectSelecteVoies();
-#endif
 			SambaRunDate();
 			if(Archive.enservice) {
 				if(!LectModeSpectresAuto) {
@@ -8809,9 +8805,7 @@ int LectAcqStdThread() {
 		}
 
 		/* Initialisation des variables globales de la branche Lecture */
-#ifndef WXWIDGETS
 		if(!LectConstruitTampons(LectureLog)) return(0);
-#endif
 		if(LectSession < 2) LectJournalTrmt();
 		LectRazCompteurs();
 		if((LectSession < 2) && (SequenceCourante >= 0)) {
@@ -8865,12 +8859,12 @@ int LectAcqStdThread() {
 	
 		/* Execution de la tache de lecture */
 #ifdef WXWIDGETS
-		UnlockPaintEvents();
+//		UnlockPaintEvents();
 #endif
 		erreur_acq = LectExec(NUMER_MODE_ACQUIS);
 
 #ifdef WXWIDGETS
-		LockPaintEvents();
+//		LockPaintEvents();
 #endif
 		MonitEvtDetach();
 
@@ -9061,15 +9055,15 @@ int LectAcqStdThread() {
 	return(0);
 }
 
-int LectAcqStdThreadWrapper() {
+/*int LectAcqStdThreadWrapper() {
 	// do a wrapper to ensure the painting lock is released
 	LockPaintEvents();
 	int ret = LectAcqStdThread();
 	UnlockPaintEvents();
 	return ret;
-}
+}*/
 
-int LectAcqStd() {
+/*int LectAcqStd() {
 
 #ifdef WXWIDGETS
 	if(LectSession < 2) {
@@ -9085,7 +9079,7 @@ int LectAcqStd() {
 #else
 	return LectAcqStdThread();
 #endif
-}
+}*/
 
 #ifdef SPECTRES_SEQUENCES
 /* ========================================================================== */
@@ -9879,6 +9873,14 @@ int LectDemarre() {
 #endif
 	return(0);
 }
+
+int LectDemarreMT() {
+	// call LectDemarre in a separate thread to avoid blocking
+	pthread_t thd;
+	int t = pthread_create(&thd, NULL, LectDemarre, NULL);
+	return 0;
+}
+
 /* ========================================================================== */
 int LectEtat() {
 /* /docFuncBeg {LectEtat}
@@ -10317,7 +10319,12 @@ MenuItem iLectSpectreControle[] = {
 };
 #endif /* SPECTRES_COMPACTE */
 
+#ifdef WXWIDGETS
+static MenuItem iLectDemarrage[] = { { "Demarrer", MNU_FONCTION LectDemarreMT }, MNU_END };
+#else
 static MenuItem iLectDemarrage[] = { { "Demarrer", MNU_FONCTION LectDemarre }, MNU_END };
+#endif
+
 static MenuItem iLectArret[]     = { { "Stopper ", MNU_FONCTION LectStop }, MNU_END };
 static MenuItem iLectRegen[]     = { { "Lancer  regeneration",   MNU_FONCTION LectRegenChange }, MNU_END };
 static MenuItem iLectSupplements[] = {

--- a/samba/lect.c
+++ b/samba/lect.c
@@ -7997,8 +7997,6 @@ relance:
 			}
 		}
 		if(SambaInfos && !SambaInfos->en_cours) LectStop();
-
-		}
 	}
 		if(SambaInfos) SambaInfos->en_cours = Acquis[AcquisLocale].etat.active;
 		if(LectErreur.code == LECT_ARRETE) LectRelancePrevue = 1; else

--- a/samba/lect.c
+++ b/samba/lect.c
@@ -6446,7 +6446,7 @@ INLINE char SambaDeclenche(int voie, float reelle) {
 	/* Style de recherche */
 	if(VoieTampon[voie].trig.cherche == TRGR_EXTREMA) {
 #ifdef DEBUG_TRIGGER
-		if(!TrmtDejaDit) printf("Recherche des extremas (signal %g -> %g, deja %d0 µs passees)\n",
+		if(!TrmtDejaDit) printf("Recherche des extremas (signal %g -> %g, deja %d0 ï¿½s passees)\n",
 								suivi->precedente,reelle,VoieTampon[voie].signal.climbs);
 #endif
 		/* On recherche un pic => on regarde le changement de derivee */
@@ -6459,7 +6459,7 @@ INLINE char SambaDeclenche(int voie, float reelle) {
 			amplitude = niveau - VoieTampon[voie].signal.base;
 			montee = (float)(abs(VoieTampon[voie].signal.climbs)) * VoieEvent[voie].horloge;
 		#ifdef DEBUG_TRIGGER
-			if(!TrmtDejaDit) printf("Depuis %d%03d,%02d0 ms sur %3g µs: montee de %4d ADU a partir de %4d\n",
+			if(!TrmtDejaDit) printf("Depuis %d%03d,%02d0 ms sur %3g ï¿½s: montee de %4d ADU a partir de %4d\n",
 				(int)suivi->dernierpic/1000000,Modulo(suivi->dernierpic,1000000)/100,Modulo(suivi->dernierpic,1000000)%100,
 				montee,amplitude,VoieTampon[voie].signal.base);
 		#endif
@@ -6475,7 +6475,7 @@ INLINE char SambaDeclenche(int voie, float reelle) {
 				*(VoieTampon[voie].adrs_niveau) = suivi->precedente - amplitude;
 				*(VoieTampon[voie].adrs_duree) = duree;
 			#ifdef DEBUG_PRGM_0
-				if(!TrmtDejaDit) printf("Calcul pour amplitude %f sur %f µs au niveau %f\n",
+				if(!TrmtDejaDit) printf("Calcul pour amplitude %f sur %f ï¿½s au niveau %f\n",
 					*(VoieTampon[voie].adrs_amplitude),*(VoieTampon[voie].adrs_montee),*(VoieTampon[voie].adrs_niveau));
 				if(!TrmtDejaDit) CebExec(TrmtPrgm,1); else
 
@@ -7606,25 +7606,150 @@ struct arg_struct {
     NUMER_MODE mode;
 };
 
-TypeADU LectExecThread(void *arguments)
-{
-	struct arg_struct *args = arguments;
-	int n,m;
-	int64 depuis_depile;
-	int bolo;
-	char entretien_bolo;
- 	int64 synchroD2traitees;
-	int64 maintenant;
-	int avant = 0, secs;
-	char delai[DATE_MAX];
-	char pair = 0;
-	int loop_num = 0;
+static TypeADU LectExec(NUMER_MODE mode) {
+/* /docFuncBeg {LectExec}
+   	/docFuncReturn  {0 si OK, code d'erreur sinon (voir LectAcqStd)}
+   	/docFuncSubject {Tache de lecture, avec retour seulement si erreur ou Acquis[AcquisLocale].etat.active=0}
+*/
+	char diese,boostee,it_demandees,entretien_bolo,log,ok; int n,m;
+	int64 synchroD2traitees,min_restart,ip_avant; int64 depuis_depile;
+	int64 maintenant; char pair; int avant,secs; char delai[DATE_MAX];
 	TypeADU erreur_acq;
-	char ok;
-	char it_demandees = args->it_demandees;
-	char boostee = args->boostee;
-	NUMER_MODE mode = args->mode;
-	int64 min_restart, ip_avant;
+	FILE *f;
+	int bolo;
+
+/*
+ * Initialisations
+ * ---------------
+ */
+	if(SettingsMultitasks == 1) {
+		if(SambaPartage && (SambaPartageId == -1)) {
+			printf("* Liberation de la variable globale SambaPartage[%d] en 0x%08X\n",SambaPartageDim,(hexa)SambaPartage);
+			free(SambaPartage); SambaPartage = 0;
+		}
+		if(!SambaPartage) {
+			SambaPartageId = shmget(IPC_PRIVATE,SambaPartageDim,0644|IPC_CREAT|IPC_EXCL);
+			/* printf("Identifieur cree: %d\n",SambaPartageId); */
+			printf("* shmget(%d octets) a rendu SambaPartageId=%08X (errno=%d)\n",SambaPartageDim,SambaPartageId,errno);
+			if(SambaPartageId != -1) SambaPartage = (TypeSambaPartagee *)shmat(SambaPartageId,0,SHM_RND);
+		}
+	} else {
+		if(SambaPartage && (SambaPartageId != -1)) {
+			printf("* Liberation de la variable partagee SambaPartage[%d] en 0x%08X\n",SambaPartageDim,(hexa)SambaPartage);
+			int i; i = 256; while((shmdt(SambaPartage) != -1) && i) i-- ; SambaPartage = 0; SambaPartageId = -1;
+		}
+		if(!SambaPartage) SambaPartage = (TypeSambaPartagee *)malloc(SambaPartageDim);
+	}
+	if(SambaPartage) printf("* Variable %s SambaPartage[%d] allouee en 0x%08X\n",(SambaPartageId == -1)? "globale": "partagee",SambaPartageDim,(hexa)SambaPartage);
+	else {
+		printf("* Allocation de la variable %s SambaPartage[%d] en erreur: %s\n",(SambaPartageId == -1)? "globale": "partagee",SambaPartageDim,strerror(errno));
+		printf("  => Lecture sous interruption en mode v4\n");
+		SettingsMultitasks = 4;
+	}
+
+	boostee = (SettingsMultitasks && !LectParBloc);
+	if(boostee) {
+		if((SettingsMultitasks <= 1)
+		|| (LectCntl.LectMode == LECT_IDENT)
+		|| (LectCntl.LectMode == LECT_COMP)
+		|| LectSurFichier) it_demandees = 0;
+		else it_demandees = 1;
+	} else it_demandees = 0; /* gcc.. */
+    log = (LectureLog || LectLogComp);
+/*	it_demandees = 0;  pour mise au point */
+	LectErreursNb = 0;
+#ifndef PAS_D_ERREUR_PERMISE
+	LectErreur1 = 0;
+#endif
+	LectArretePoliment = 0;
+	sprintf(RunDateDebut,"%s a %s",DateCivile(),DateHeure());
+	printf("* Demarrage le %s\n",RunDateDebut);
+	LectJournalDemarrage();
+
+/*
+ * Enregistrements divers
+ * ----------------------
+ */
+	if(Archive.enservice && EdbServeur[0] && strcmp(EdbServeur,"neant")) {
+		f = fopen("RunInfo","r");
+		if(f) {
+			DbSendFile(EdbServeur,ArchiveId,f);
+			if(DbStatus) printf("%s/ Base de Donnees renseignee (Id: %s, rev: %s)\n",DateHeure(),DbId,DbRev);
+			else printf("%s/ ! Renseignement Base de Donnees en erreur (%s, raison: %s)\n",DateHeure(),DbErreur,DbRaison);
+			fclose(f);
+			remove("RunInfo");
+		}
+	}
+	if(Archive.enservice && (LectCntl.LectMode == LECT_DONNEES) && (LectSession < 2)) {
+		FILE *f;
+		//- strcat(strcpy(FichierCatalogue,CtlgPath),"Catalogue");
+		f = fopen(FichierCatalogue,"r");
+		if(!f) {
+			RepertoireCreeRacine(FichierCatalogue);
+			f = fopen(FichierCatalogue,"w");
+			if(f) fprintf(f,"# Date    heure   nom       mode  type      duree  taille(MB)  expo(Kg.j)   evts\n");
+		} else {
+			int car;
+			fseek(f,-1,SEEK_END);
+			car = fgetc(f);
+			fclose(f);
+			f = fopen(FichierCatalogue,"a");
+			if(car != '\n') {
+				printf("%s/ Fermeture de la derniere ligne du catalogue\n",DateHeure());
+				fprintf(f," inconnue  inconnue    inconnue     --\n");
+			}
+		}
+		if(f) {
+			char *c; int i,j,k; char *type;
+			LectCommentComplet[0] = '\0'; c = &(LectComment[0][0]);
+			for(i=0; i<MAXCOMMENTNB; i++) if(LectComment[i][0] != '\0') {
+				c = &(LectComment[i][0]);
+				for(j=0; j<MAXCOMMENTLNGR-2; j++) {
+					if((LectComment[i][j] != ' ') && (LectComment[i][j] != 0x09)) c = &(LectComment[i][j]);
+				}
+				c++; *c = '\0';
+				if(i) strcat(strcat(LectCommentComplet," "),LectComment[i]);
+				else strcpy(LectCommentComplet,LectComment[i]);
+			}
+			if((SettingsRunFamille == RUN_FAMILLE_BANC) && (RunTypeName >= 0)) {
+				EnvirVarPrintVal(&(EnvirVar[RunTypeVar]),RunTypeName,TYPERUN_NOM);
+				type = RunTypeName;
+			} else {
+				ArgKeyGetText(RunCategCles,LectCntl.RunCategNum,RunCategName,TYPERUN_NOM);
+				type = RunCategName;
+			}
+			fprintf(f,"%8s %8s %8s %6s %-6s",DateJour(),DateHeure(),Acquis[AcquisLocale].etat.nom_run,
+					(Trigger.demande == NEANT)? "stream": "event",type);
+			for(k=0; k<ExportPackNb; k++) if((ExportPack[k].support_type == EXPORT_CATALOGUE) && (ExportPack[k].quand == EXPORT_RUN_DEBUT)) {
+				if(!diese) { fprintf(f," # "); diese = 1; }
+				ExporteInfos(f,k);
+			}
+			fflush(f);
+			fclose(f);
+			printf("%s/ Mise a jour du catalogue (%s)\n",DateHeure(),FichierCatalogue);
+		} else printf("%s/ Mise a jour du catalogue impossible, fichier inaccessible:\n            '%s'\n",
+					  DateHeure(),FichierCatalogue);
+		if(SettingsChargeBolos && !LectModeSpectresAuto && !RegenEnCours) DetecteurChargeTous(log?"         ":0);
+	};
+	if(TrmtRegulActive && ArchSauve[EVTS]) {
+		int secs,usecs;
+#ifndef CODE_WARRIOR_VSN
+		gettimeofday(&LectDateRun,0);
+		ArchT0sec = LectDateRun.tv_sec;
+		ArchT0msec = LectDateRun.tv_usec;
+#endif /* CODE_WARRIOR_VSN */
+		SambaTempsEchantillon(DernierPointTraite,ArchT0sec,ArchT0msec,&secs,&usecs);					
+		ArchiveSeuils(secs);
+	}
+
+/*
+ * Depart sur une synchro (D2 ou D3)
+ * ---------------------------------
+ */
+		struct arg_struct args;
+		args.boostee = boostee;
+		args.it_demandees = it_demandees;
+		args.mode = mode;
 
 relance:
 	min_restart = 100; // 5000; // 5s
@@ -7985,163 +8110,6 @@ relance:
 		return(LectMessageArret(_ORIGINE_,7,LECT_NFND));
 	}
 
-	
-}
-
-static TypeADU LectExec(NUMER_MODE mode) {
-/* /docFuncBeg {LectExec}
-   	/docFuncReturn  {0 si OK, code d'erreur sinon (voir LectAcqStd)}
-   	/docFuncSubject {Tache de lecture, avec retour seulement si erreur ou Acquis[AcquisLocale].etat.active=0}
-*/
-	char diese,boostee,it_demandees,entretien_bolo,log,ok; int n,m;
-	int64 synchroD2traitees,min_restart,ip_avant; int64 depuis_depile;
-	int64 maintenant; char pair; int avant,secs; char delai[DATE_MAX];
-	TypeADU erreur_acq;
-	FILE *f;
-	int bolo;
-
-/*
- * Initialisations
- * ---------------
- */
-	if(SettingsMultitasks == 1) {
-		if(SambaPartage && (SambaPartageId == -1)) {
-			printf("* Liberation de la variable globale SambaPartage[%d] en 0x%08X\n",SambaPartageDim,(hexa)SambaPartage);
-			free(SambaPartage); SambaPartage = 0;
-		}
-		if(!SambaPartage) {
-			SambaPartageId = shmget(IPC_PRIVATE,SambaPartageDim,0644|IPC_CREAT|IPC_EXCL);
-			/* printf("Identifieur cree: %d\n",SambaPartageId); */
-			printf("* shmget(%d octets) a rendu SambaPartageId=%08X (errno=%d)\n",SambaPartageDim,SambaPartageId,errno);
-			if(SambaPartageId != -1) SambaPartage = (TypeSambaPartagee *)shmat(SambaPartageId,0,SHM_RND);
-		}
-	} else {
-		if(SambaPartage && (SambaPartageId != -1)) {
-			printf("* Liberation de la variable partagee SambaPartage[%d] en 0x%08X\n",SambaPartageDim,(hexa)SambaPartage);
-			int i; i = 256; while((shmdt(SambaPartage) != -1) && i) i-- ; SambaPartage = 0; SambaPartageId = -1;
-		}
-		if(!SambaPartage) SambaPartage = (TypeSambaPartagee *)malloc(SambaPartageDim);
-	}
-	if(SambaPartage) printf("* Variable %s SambaPartage[%d] allouee en 0x%08X\n",(SambaPartageId == -1)? "globale": "partagee",SambaPartageDim,(hexa)SambaPartage);
-	else {
-		printf("* Allocation de la variable %s SambaPartage[%d] en erreur: %s\n",(SambaPartageId == -1)? "globale": "partagee",SambaPartageDim,strerror(errno));
-		printf("  => Lecture sous interruption en mode v4\n");
-		SettingsMultitasks = 4;
-	}
-
-	boostee = (SettingsMultitasks && !LectParBloc);
-	if(boostee) {
-		if((SettingsMultitasks <= 1)
-		|| (LectCntl.LectMode == LECT_IDENT)
-		|| (LectCntl.LectMode == LECT_COMP)
-		|| LectSurFichier) it_demandees = 0;
-		else it_demandees = 1;
-	} else it_demandees = 0; /* gcc.. */
-    log = (LectureLog || LectLogComp);
-/*	it_demandees = 0;  pour mise au point */
-	LectErreursNb = 0;
-#ifndef PAS_D_ERREUR_PERMISE
-	LectErreur1 = 0;
-#endif
-	LectArretePoliment = 0;
-	sprintf(RunDateDebut,"%s a %s",DateCivile(),DateHeure());
-	printf("* Demarrage le %s\n",RunDateDebut);
-	LectJournalDemarrage();
-
-/*
- * Enregistrements divers
- * ----------------------
- */
-	if(Archive.enservice && EdbServeur[0] && strcmp(EdbServeur,"neant")) {
-		f = fopen("RunInfo","r");
-		if(f) {
-			DbSendFile(EdbServeur,ArchiveId,f);
-			if(DbStatus) printf("%s/ Base de Donnees renseignee (Id: %s, rev: %s)\n",DateHeure(),DbId,DbRev);
-			else printf("%s/ ! Renseignement Base de Donnees en erreur (%s, raison: %s)\n",DateHeure(),DbErreur,DbRaison);
-			fclose(f);
-			remove("RunInfo");
-		}
-	}
-	if(Archive.enservice && (LectCntl.LectMode == LECT_DONNEES) && (LectSession < 2)) {
-		FILE *f;
-		//- strcat(strcpy(FichierCatalogue,CtlgPath),"Catalogue");
-		f = fopen(FichierCatalogue,"r");
-		if(!f) {
-			RepertoireCreeRacine(FichierCatalogue);
-			f = fopen(FichierCatalogue,"w");
-			if(f) fprintf(f,"# Date    heure   nom       mode  type      duree  taille(MB)  expo(Kg.j)   evts\n");
-		} else {
-			int car;
-			fseek(f,-1,SEEK_END);
-			car = fgetc(f);
-			fclose(f);
-			f = fopen(FichierCatalogue,"a");
-			if(car != '\n') {
-				printf("%s/ Fermeture de la derniere ligne du catalogue\n",DateHeure());
-				fprintf(f," inconnue  inconnue    inconnue     --\n");
-			}
-		}
-		if(f) {
-			char *c; int i,j,k; char *type;
-			LectCommentComplet[0] = '\0'; c = &(LectComment[0][0]);
-			for(i=0; i<MAXCOMMENTNB; i++) if(LectComment[i][0] != '\0') {
-				c = &(LectComment[i][0]);
-				for(j=0; j<MAXCOMMENTLNGR-2; j++) {
-					if((LectComment[i][j] != ' ') && (LectComment[i][j] != 0x09)) c = &(LectComment[i][j]);
-				}
-				c++; *c = '\0';
-				if(i) strcat(strcat(LectCommentComplet," "),LectComment[i]);
-				else strcpy(LectCommentComplet,LectComment[i]);
-			}
-			if((SettingsRunFamille == RUN_FAMILLE_BANC) && (RunTypeName >= 0)) {
-				EnvirVarPrintVal(&(EnvirVar[RunTypeVar]),RunTypeName,TYPERUN_NOM);
-				type = RunTypeName;
-			} else {
-				ArgKeyGetText(RunCategCles,LectCntl.RunCategNum,RunCategName,TYPERUN_NOM);
-				type = RunCategName;
-			}
-			fprintf(f,"%8s %8s %8s %6s %-6s",DateJour(),DateHeure(),Acquis[AcquisLocale].etat.nom_run,
-					(Trigger.demande == NEANT)? "stream": "event",type);
-			for(k=0; k<ExportPackNb; k++) if((ExportPack[k].support_type == EXPORT_CATALOGUE) && (ExportPack[k].quand == EXPORT_RUN_DEBUT)) {
-				if(!diese) { fprintf(f," # "); diese = 1; }
-				ExporteInfos(f,k);
-			}
-			fflush(f);
-			fclose(f);
-			printf("%s/ Mise a jour du catalogue (%s)\n",DateHeure(),FichierCatalogue);
-		} else printf("%s/ Mise a jour du catalogue impossible, fichier inaccessible:\n            '%s'\n",
-					  DateHeure(),FichierCatalogue);
-		if(SettingsChargeBolos && !LectModeSpectresAuto && !RegenEnCours) DetecteurChargeTous(log?"         ":0);
-	};
-	if(TrmtRegulActive && ArchSauve[EVTS]) {
-		int secs,usecs;
-#ifndef CODE_WARRIOR_VSN
-		gettimeofday(&LectDateRun,0);
-		ArchT0sec = LectDateRun.tv_sec;
-		ArchT0msec = LectDateRun.tv_usec;
-#endif /* CODE_WARRIOR_VSN */
-		SambaTempsEchantillon(DernierPointTraite,ArchT0sec,ArchT0msec,&secs,&usecs);					
-		ArchiveSeuils(secs);
-	}
-
-/*
- * Depart sur une synchro (D2 ou D3)
- * ---------------------------------
- */
-		struct arg_struct args;
-		args.boostee = boostee;
-		args.it_demandees = it_demandees;
-		args.mode = mode;
-
-#ifdef WXWIDGETS
-		// Send off the thread for the actual DAQ
-		pthread_t lectexec_thread;
-		int t = pthread_create(&lectexec_thread, NULL, LectExecThread, 
-			(void*)&args);
-		return 0;
-#else
-		return LectExecThread((void*)&args);
-#endif
 }
 /* /docFuncEnd */
 /* ========================================================================== */
@@ -8643,7 +8611,7 @@ int LectAcqElementaire(NUMER_MODE mode) {
 	return(0);
 }
 /* ========================================================================== */
-int LectAcqStd() {
+int LectAcqStdThread() {
 	int rep,voie,rc,i,k,l,num,fmt; char doit_terminer;
 	TypeADU erreur_acq;
 	float nb;
@@ -8684,12 +8652,16 @@ int LectAcqStd() {
 #endif
 	do {
 		if(LectSession < 2) {
+#ifndef WXWIDGETS
 			if(!LectFixeMode(LECT_DONNEES,1)) return(0);
+#endif
 			for(rep=0; rep<RepartNb; rep++) {
 				Repart[rep].mode = 0;
 				Repart[rep].status_demande = 0;
 			}
+#ifndef WXWIDGETS
 			LectSelecteVoies();
+#endif
 			SambaRunDate();
 			if(Archive.enservice) {
 				if(!LectModeSpectresAuto) {
@@ -8846,7 +8818,9 @@ int LectAcqStd() {
 		}
 
 		/* Initialisation des variables globales de la branche Lecture */
+#ifndef WXWIDGETS
 		if(!LectConstruitTampons(LectureLog)) return(0);
+#endif
 		if(LectSession < 2) LectJournalTrmt();
 		LectRazCompteurs();
 		if((LectSession < 2) && (SequenceCourante >= 0)) {
@@ -8901,9 +8875,6 @@ int LectAcqStd() {
 		/* Execution de la tache de lecture */
 		erreur_acq = LectExec(NUMER_MODE_ACQUIS);
 
-#ifdef WXWIDGETS
-		return 0;
-#endif
 		/* Remise en etat des affichages */
 		if(OpiumDisplayed(bLecture)) doit_terminer = OpiumRefreshBegin(bLecture); else doit_terminer = 0;
 		MenuItemAllume(mLectDemarrage,1,L_("Demarrer"),GRF_RGB_YELLOW);
@@ -9089,6 +9060,25 @@ int LectAcqStd() {
 
 	return(0);
 }
+
+int LectAcqStd() {
+
+#ifdef WXWIDGETS
+	if(LectSession < 2) {
+		if (!LectFixeMode(LECT_DONNEES,1)) return (0);
+		LectSelecteVoies();
+	}
+	if (!LectConstruitTampons(LectureLog)) return (0);
+
+	// Send off the thread for the actual DAQ
+	pthread_t lectacqstd_thread;
+	int t = pthread_create(&lectacqstd_thread, NULL, LectAcqStdThread, NULL);
+	return 0;
+#else
+	return LectAcqStdThread();
+#endif
+}
+
 #ifdef SPECTRES_SEQUENCES
 /* ========================================================================== */
 int LectSpectresClassiques() {

--- a/samba/monit.c
+++ b/samba/monit.c
@@ -2543,6 +2543,16 @@ static float MonitTraiteeOf7(int voie, TypeTamponDonnees *tampon, int lngr, int6
 	base = (base / (double)nb);
 	return((float)base);
 }
+
+/* ========================================================================== */
+int MonitEvtDetach() {
+	Graph g;
+	if(OpiumDisplayed((gEvtPlanche->cdr)->planche)) g = gEvtPlanche; else g = gEvtSolo;
+
+	GraphDataDisconnect(g,0);
+	GraphDataDisconnect(g,1);
+}
+
 /* ========================================================================== */
 int MonitEvtAffiche(int lequel, void *qui, int affiche) {
 	int voietrig,vm,vt;

--- a/samba/monit.h
+++ b/samba/monit.h
@@ -180,6 +180,7 @@ void MonitFenClear(TypeMonitFenetre *f);
 void MonitFenFree(TypeMonitFenetre *f);
 float MonitUnitesADU(Graph g, int sens, float val);
 int MonitEvtAffiche(int lequel, void *qui, int affiche);
+int MonitEvtDetach();
 int MonitEvtPrecedent(Menu menu, MenuItem *item);
 int MonitEvtSuivant(Menu menu, MenuItem *item);
 int MonitSauve();


### PR DESCRIPTION
Got a proper implementation of the thread system working. The idea now is that any GUI calls that would run code with it's own GUI calls to OpiumUserAction (e.g. LectStdAcq) should get sent off into their own thread **immediately**. The wxWidgets interface layer will then trigger events to be picked up by the main thread.

This PR also includes a number of other minor bug fixes, etc.